### PR TITLE
Html support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 client_session_key.aes
 dist
+*_flymake.hs
+.cabal-sandbox/
+cabal.sandbox.config

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2012, Katsutoshi Itoh
+Copyright (c) 2014, Marcellus Siegburg
 
 All rights reserved.
 

--- a/Yesod/Goodies/PNotify.hs
+++ b/Yesod/Goodies/PNotify.hs
@@ -32,16 +32,17 @@ data PNotify = PNotify
 data NotifyType = Notice | Info | Success | Error
                 deriving (Show, Read)
 
-data NotifyStyling = JqueryUI | Bootstrap
+data NotifyStyling = JqueryUI | Bootstrap3
                    deriving (Show, Read)
+
 
 class YesodJquery a => YesodJqueryPnotify a where
   urlPnotifyJs :: a -> Either (Route a) Text
-  urlPnotifyJs _ = Right "http://cdn.jsdelivr.net/pnotify/1.2/jquery.pnotify.min.js"
+  urlPnotifyJs _ = Right "http://cdn.jsdelivr.net/pnotify/2.0.0/pnotify.all.min.js"
   urlPnotifyCss :: a -> Either (Route a) Text
-  urlPnotifyCss _ = Right "http://cdn.jsdelivr.net/pnotify/1.2/jquery.pnotify.default.css"
+  urlPnotifyCss _ = Right "http://cdn.jsdelivr.net/pnotify/2.0.0/pnotify.all.min.css"
   urlPnotifyIconsCss :: a -> Either (Route a) Text
-  urlPnotifyIconsCss _ = Right "http://cdn.jsdelivr.net/pnotify/1.2/jquery.pnotify.default.icons.css"
+  urlPnotifyIconsCss _ = Right "http://cdn.jsdelivr.net/pnotify/2.0.0/pnotify.picon.css"
 
 notifyKey :: Text
 notifyKey = "_PNotify"
@@ -74,4 +75,4 @@ pnotify y = do
       addStylesheetEither $ urlPnotifyIconsCss y
       let toJs p = [julius|{styling:'#{rawJS $ map toLower $ show $ sty p}',title:'#{rawJS $ ttl p}',text:'#{rawJS $ msg p}',type:'#{rawJS $ map toLower $ show $ typ p}'},|]
           ws = foldr ((<>).toJs) mempty ps
-      toWidget [julius|$(document).ready(function(e){var ws=[^{ws}];for(var i in ws){$.pnotify(ws[i]);}});|]
+      toWidget [julius|$(document).ready(function(e){var ws=[^{ws}];for(var i in ws){new PNotify(ws[i]);}});|]

--- a/Yesod/Goodies/PNotify.hs
+++ b/Yesod/Goodies/PNotify.hs
@@ -17,6 +17,7 @@ import Data.Text (Text)
 import Data.Monoid ((<>), mempty)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import qualified Text.Blaze.Html.Renderer.Text as RT
 import Control.Monad.Trans.Maybe
 import Data.Char (toLower)
 import Text.Julius (RawJS(..))
@@ -24,10 +25,29 @@ import Text.Julius (RawJS(..))
 data PNotify = PNotify 
                { sty :: NotifyStyling
                , typ :: NotifyType
-               , ttl :: Text
-               , msg :: Text
+               , ttl :: Html
+               , msg :: Html
                }
-             deriving (Show, Read)
+
+data PNotify_ = PNotify_
+                { _sty :: NotifyStyling
+                , _typ :: NotifyType
+                , _ttl :: Text
+                , _msg :: Text
+                }
+              deriving (Show, Read)
+
+toInternal (PNotify s tp t m) =
+    PNotify_ { _sty = s
+             , _typ = tp
+             , _ttl = T.concat . TL.toChunks . RT.renderHtml $ t
+             , _msg = T.concat . TL.toChunks . RT.renderHtml $ m}
+
+fromInternal (PNotify_ s tp t m) =
+    PNotify { sty = s
+            , typ = tp
+            , ttl = preEscapedToMarkup t
+            , msg = preEscapedToMarkup m}
 
 data NotifyType = Notice | Info | Success | Error
                 deriving (Show, Read)
@@ -48,13 +68,18 @@ notifyKey :: Text
 notifyKey = "_PNotify"
 
 _setPNotify :: [PNotify] -> HandlerT site IO ()
-_setPNotify = setSession notifyKey . T.concat . TL.toChunks . TL.pack . show
+_setPNotify ps = setSession notifyKey . T.concat . TL.toChunks . TL.pack . show $ map toInternal ps
 
-getPNotify :: HandlerT site IO (Maybe [PNotify])
-getPNotify = runMaybeT $ do
+_getPNotify :: HandlerT site IO (Maybe [PNotify_])
+_getPNotify = runMaybeT $ do
   ns <- MaybeT $ lookupSession notifyKey
   lift $ deleteSession notifyKey
   return $ read $ T.unpack ns
+
+getPNotify :: HandlerT site IO (Maybe [PNotify])
+getPNotify = runMaybeT $ do
+  ps <- MaybeT _getPNotify
+  return $ map fromInternal ps
 
 setPNotify :: PNotify -> HandlerT site IO ()
 setPNotify n = do
@@ -63,16 +88,16 @@ setPNotify n = do
 
 pnotify :: YesodJqueryPnotify site => site -> WidgetT site IO ()
 pnotify y = do
-  mnotify <- handlerToWidget getPNotify
+  mnotify <- handlerToWidget _getPNotify
   case mnotify of
     Nothing -> return ()
-    Just ps -> do
+    Just _ps -> do
       addScriptEither $ urlJqueryJs y
       addScriptEither $ urlJqueryUiJs y
       addStylesheetEither $ urlJqueryUiCss y
       addScriptEither $ urlPnotifyJs y
       addStylesheetEither $ urlPnotifyCss y
       addStylesheetEither $ urlPnotifyIconsCss y
-      let toJs p = [julius|{styling:'#{rawJS $ map toLower $ show $ sty p}',title:'#{rawJS $ ttl p}',text:'#{rawJS $ msg p}',type:'#{rawJS $ map toLower $ show $ typ p}'},|]
-          ws = foldr ((<>).toJs) mempty ps
+      let toJs p = [julius|{styling:'#{rawJS $ map toLower $ show $ _sty p}',title:'#{rawJS $ _ttl p}',text:'#{rawJS $ _msg p}',type:'#{rawJS $ map toLower $ show $ _typ p}'},|]
+          ws = foldr ((<>).toJs) mempty _ps
       toWidget [julius|$(document).ready(function(e){var ws=[^{ws}];for(var i in ws){new PNotify(ws[i]);}});|]

--- a/sample.hs
+++ b/sample.hs
@@ -4,6 +4,7 @@ import Yesod
 import Yesod.Form.Jquery
 import Data.Text (Text)
 import Control.Applicative ((<$>),(<*>))
+import Text.Blaze.Html (preEscapedToHtml)
 
 import Yesod.Goodies.PNotify
 
@@ -62,9 +63,12 @@ postPersonR = do
   ((result, _), _) <- runFormPost personForm
   case result of
     FormSuccess _ -> do 
-      setPNotify $ PNotify JqueryUI Success "Updated" "Update User profile."
-      setPNotify $ PNotify JqueryUI Notice "Notice" "More notice."
-      setPNotify $ PNotify JqueryUI Info "Information" "And more information."
+      let updateMsg = "<b>Update</b> User profile." :: Text
+          info = "<i>Information</i>" :: Text
+          infoMsg = "And <u>more</u> information." :: Text
+      setPNotify $ PNotify JqueryUI Success "Updated" $ preEscapedToHtml updateMsg
+      setPNotify $ PNotify JqueryUI Notice "Notice" "More notice. <no tag>"
+      setPNotify $ PNotify JqueryUI Info (preEscapedToHtml info) $ preEscapedToHtml infoMsg
       redirect PersonR
     _ -> do
       setPNotify $ PNotify JqueryUI Error "Error" "Fail to update user profile"

--- a/yesod-pnotify.cabal
+++ b/yesod-pnotify.cabal
@@ -24,3 +24,4 @@ library
                        , text >= 0.11 && < 2.0
                        , transformers >= 0.3 && < 0.5
                        , shakespeare >= 2.0 && < 2.1
+                       , blaze-html >= 0.5.0.0 && < 0.8

--- a/yesod-pnotify.cabal
+++ b/yesod-pnotify.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                yesod-pnotify
-version:             0.5.0
+version:             0.6.0
 synopsis:            Yet another getMessage/setMessage using pnotify jquery plugins
 description:         Yet another getMessage/setMessage using pnotify jquery plugins
 homepage:            https://github.com/cutsea110/yesod-pnotify
@@ -19,8 +19,8 @@ library
   exposed-modules:     Yesod.Goodies.PNotify
   -- other-modules:       
   build-depends:         base >= 4.6 && < 4.8
-                       , yesod >= 1.2 && < 1.3
-                       , yesod-form >= 1.3 && < 1.4
-                       , text >= 0.11 && < 1.3
+                       , yesod >= 1.2 && < 1.5
+                       , yesod-form >= 1.3 && < 1.5
+                       , text >= 0.11 && < 2.0
                        , transformers >= 0.3 && < 0.5
                        , shakespeare >= 2.0 && < 2.1


### PR DESCRIPTION
This update improves:
- compatibility (to newer versions of yesod)
- flexibility (by changing the type from Text to Html; the previous behavior is still possible)

Radical changes:
- new version of pnotify (now: 2.0.0)
- constructor of type NotifyStyling Bootstrap changed to Bootstrap3
